### PR TITLE
Add thing docker and cli instructions.

### DIFF
--- a/doc/thing/thing-cli.rst
+++ b/doc/thing/thing-cli.rst
@@ -1,0 +1,96 @@
+Using CLI
+=========
+
+.. note:: In order to use the KNoT CLI, it is necessary to fulfill the `requirements <thing-requirements.html>`_.
+
+----------------------------------------------------------------
+
+There are many commands that you can call when using the knot script (cli.py). Some of their functions are:
+
+Set default target board
+------------------------
+- You can set the default target board with the command:
+
+.. code-block:: bash
+
+   $ knot board <BOARD>
+
+Where `<BOARD>` can be 'dk' or 'dongle'.
+
+----------------------------------------------------------------
+
+Set external OpenThread path
+----------------------------
+
+To avoid downloading the OpenThread repo on every new build, set an external path.
+
+- Clone Openthread Github repository:
+
+.. code-block:: bash
+
+   $ git clone https://github.com/openthread/openthread.git
+
+
+- Checkout to the compatible hash and set it as default:
+
+.. code-block:: bash
+
+   $ cd openthread
+   $ git checkout -b knot_hash f9d757a161fea4775d033a1ce88cf7962fe24a93
+   $ knot ot-path `pwd`
+
+----------------------------------------------------------------
+
+Clear project before building
+-----------------------------
+
+The user can delete old building files before compiling again.
+
+.. note:: This is especially useful when the project had important changes like different target board or dependency repository.
+
+- Clear old files before compiling:
+
+.. code-block:: bash
+
+   $ knot make --clean
+
+----------------------------------------------------------------
+
+Flash board when done
+---------------------
+
+The user can flash the board just after building it.
+
+- Flash board after building:
+
+.. code-block:: bash
+
+   $ knot make --flash
+
+.. note:: This option also flashes the bootloader when targeting the Dongle.
+
+----------------------------------------------------------------
+
+Flash bootloader
+----------------
+
+When using the DK, it's possible for the board to be flashed without the bootloader.
+To fix that, the user should flash it separately.
+
+- Flash bootloader to board:
+
+.. code-block:: bash
+
+   $ knot mcuboot
+
+.. note:: This option also erases the main app when targeting the Dongle.
+
+----------------------------------------------------------------
+
+Other commands
+--------------
+These and the other commands are described when using the help command:
+
+.. code-block:: bash
+
+	$ knot --help

--- a/doc/thing/thing-docker.rst
+++ b/doc/thing/thing-docker.rst
@@ -1,0 +1,101 @@
+Using Docker
+============
+
+The Docker image can be used to ease building new apps using a pre-configured
+environment.
+
+It supports Docker for Mac, Linux and Windows.
+
+To build or run the image, you have to `install Docker <https://docs.docker.com/install/>`_.
+
+----------------------------------------------------------------
+
+Building image
+--------------
+
+Build it by the tag `knot-zephyr-sdk`.
+
+.. code-block:: bash
+
+   $ docker build --tag=knot-zephyr-sdk .
+
+----------------------------------------------------------------
+
+Running the container
+---------------------
+
+Run the latest image version at CESAR's Docker Hub and pass the current working
+directory as the project folder.
+This folder shall contain all your project files.
+
+At your project folder, run:
+
+.. code-block:: bash
+
+   $ docker run -ti -v $(pwd)/:/workdir cesarbr/knot-zephyr-sdk:latest
+
+If you want to run it from an image you built, replace `cesarbr/knot-zephyr-sdk:latest`
+by the tag you used.
+
+Compile for your target board
+
+.. code-block:: bash
+
+   container> $ knot make -b {BOARD}
+
+----------------------------------------------------------------
+
+Exporting generated files
+-------------------------
+
+Export the generated files to your project's directory
+
+.. code-block:: bash
+
+   container> $ knot export /workdir/output
+
+
+The generated files can now be flashed to your device by using the
+`nRF Connect for Desktop <https://www.nordicsemi.com/?sc_itemid=%7B49D2264D-62FD-4C16-811F-88B477833C5D%7D>`_ and its
+`Programmer app <https://infocenter.nordicsemi.com/topic/ug_nc_programmer/UG/nrf_connect_programmer/ncp_introduction.html>`_.
+
+----------------------------------------------------------------
+
+Flashing on Linux
+-----------------
+
+If using a Linux device with the necessary drivers for flashing the boards,
+you may give USB access to the container.
+
+Before proceeding, make sure that you added your user to the dialout group.
+
+.. code-block:: bash
+
+   $ sudo usermod -a -G dialout `whoami`
+
+You can now access the container using the host `/dev` directory.
+
+.. code-block:: bash
+
+   $ docker run -ti --privileged -v /dev:/dev -v $(pwd)/:/workdir cesarbr/knot-zephyr-sdk:latest
+
+This will allow you to use the `--flash` flag to flash after building the project.
+
+.. code-block:: bash
+
+   container> $ knot make -b {BOARD} --flash
+
+----------------------------------------------------------------
+
+Using other knot commands
+----------------------------
+
+When inside the Docker container, you may use any KNoT command from the command line interface.
+
+To get a list of all available commands, run:
+
+.. code-block:: bash
+
+   container> $ knot --help
+
+More info is available at the `Thing CLI doc section <thing-cli.html>`_.

--- a/doc/thing/thing-requirements.rst
+++ b/doc/thing/thing-requirements.rst
@@ -1,0 +1,138 @@
+Requirements
+============
+
+Linux based OS
+--------------
+
+The actual version of KNoT Zephyr SDK is only available for Linux based systems.
+You may consider using a Virtual Machine running a Linux distribution on other systems.
+
+Zephyr
+------
+
+KNoT uses a fork of Zephyr repository.
+
+- Set up a Zephyr development environment by following these `instructions <https://docs.zephyrproject.org/latest/getting_started/index.html#set-up-a-development-system>`_.
+- Program the ``$HOME/.profile`` to always set **ZEPHYR_TOOLCHAIN_VARIANT** and **ZEPHYR_SDK_INSTALL_DIR**.
+
+.. code-block:: bash
+
+   $ echo "export ZEPHYR_TOOLCHAIN_VARIANT=zephyr" >> $HOME/.profile
+   $ echo "export ZEPHYR_SDK_INSTALL_DIR=`readlink -f <SDK-INSTALLATION-DIRECTORY>`" >> $HOME/.profile
+
+.. note:: Replace ``<SDK-INSTALLATION-DIRECTORY>`` by the actual Zephyr SDK install path
+
+- Install the west binary and bootstrapper
+
+.. code-block:: bash
+
+   $ pip3 install --user west
+
+- Create an enclosing folder and change directory
+
+.. code-block:: bash
+
+   $ mkdir zephyrproject
+   $ cd zephyrproject
+
+- Clone KNoT Zephyr fork
+
+.. code-block:: bash
+
+   $ git clone -b zephyr-knot-v1.14.0 https://github.com/CESARBR/zephyr.git
+
+- Initialize west. Inside zephyrproject directory run:
+
+.. code-block:: bash
+
+   $ west init -l zephyr/
+   $ west update
+
+.. note:: If the system can't find west, try logging out and in again.
+
+- Set up zephyr environment variables
+
+.. code-block:: bash
+
+   $ source zephyr/zephyr-env.sh
+
+- Program the ``$HOME/.profile`` to always source zephyr-env.sh when you log in.
+
+.. code-block:: bash
+
+   $ echo "source $ZEPHYR_BASE/zephyr-env.sh" >> $HOME/.profile
+
+.. note:: If you skip this step, it will be necessary to manually source zephyr-env.sh every time a new terminal is opened.
+
+
+nRF5x Command Line Tools and Segger JLink
+-----------------------------------------
+
+- Download and extract cli applications at `nRF5 Command Line Tools <https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF5-Command-Line-Tools>`_.
+
+- Install nRF5x Command Line and Segger JLink deb package:
+
+.. code-block:: bash
+
+   $ dpkg -i nrf5_tools/nRF-Command-Line-Tools_10_2_1_Linux-amd64.deb
+   $ dpkg -i nrf5_tools/JLink_Linux_V644e_x86_64.deb
+
+Source KNoT environment configuration file
+------------------------------------------
+
+- Download the zephyr-knot-sdk repository to a folder you prefer.
+
+.. code-block:: bash
+
+   $ git clone https://github.com/cesarbr/zephyr-knot-sdk/
+
+- The environment configuration file is used to set up **KNOT_BASE** path.
+
+.. code-block:: bash
+
+   $ source zephyr-knot-sdk/knot-env.sh
+
+- Program the ``$HOME/.profile`` to always source knot-env.sh when you log in.
+
+.. code-block:: bash
+
+   $ echo "source $KNOT_BASE/knot-env.sh" >> $HOME/.profile
+
+
+Add support to the KNoT command line interface
+----------------------------------------------
+
+- Add cli.py to the path files.
+
+.. code-block:: bash
+
+   $ ln -s $KNOT_BASE/scripts/cli.py $HOME/.local/bin/knot
+
+.. note:: This will allow you to call the knot command line interface from any folder.
+
+- Use pip to install cli requirements
+
+.. code-block:: bash
+
+   $ pip3 install --user -r ${KNOT_BASE}/scripts/requirements.txt
+
+.. note:: If you skip this step, it will be necessary to manually source knot-env.sh every time a new terminal is opened.
+
+KNoT protocol
+-------------
+
+- Follow the instructions to install the `KNoT protocol library <https://github.com/CESARBR/knot-protocol-source>`_.
+
+Add USB access to your user
+---------------------------
+
+- Add your user to the dialout group.
+
+.. code-block:: bash
+
+   $ sudo usermod -a -G dialout `whoami`
+
+Apply changes to profile
+------------------------
+
+- In order to apply the changes to your user, you must log out and log in again.

--- a/doc/thing/thing-requirements.rst
+++ b/doc/thing/thing-requirements.rst
@@ -5,7 +5,7 @@ Linux based OS
 --------------
 
 The actual version of KNoT Zephyr SDK is only available for Linux based systems.
-You may consider using a Virtual Machine running a Linux distribution on other systems.
+On other systems, you may consider using the `KNoT Docker <thing-docker.html>`_ (recommended) or a Virtual Machine running a Linux distribution.
 
 Zephyr
 ------

--- a/doc/thing/thing.rst
+++ b/doc/thing/thing.rst
@@ -5,4 +5,5 @@ KNoT Thing
 
    thing-requirements.rst
    thing-cli.rst
+   thing-docker.rst
    thing-api.rst

--- a/doc/thing/thing.rst
+++ b/doc/thing/thing.rst
@@ -3,4 +3,6 @@ KNoT Thing
 
 .. toctree::
 
+   thing-requirements.rst
+   thing-cli.rst
    thing-api.rst


### PR DESCRIPTION
On this PR two new sections are included on knot documentation.
The first one is instructions for KNoT CLI and second is instructions for Zephyr KNoT SDK Docker environment.