### PR TITLE
thing: samples: Add samples information

### DIFF
--- a/doc/thing/samples/basic-samples/hello-dongle.rst
+++ b/doc/thing/samples/basic-samples/hello-dongle.rst
@@ -1,0 +1,47 @@
+hello-dongle
+============
+
+Overview
+--------
+
+The hello-dongle example for ``dongle`` (nrf52840_pca10059) uses an on-board LED connected blinking every 2 seconds.
+This sample is focused on show how to register a LED as a boolean sensor using KNoT Zephyr SDK.
+
+----------------------------------------------------------------
+
+Building
+--------
+
+This sample can be built for your board in two different ways.
+
+- Using the KNoT Zephyr SDK installed on your machine:
+
+   Follow the steps described on `KNoT CLI section. <../../thing-cli.html#compile-for-your-target-board>`_
+
+- Using the KNoT Docker:
+
+   Follow the steps described on `KNoT Docker section. <../../thing-docker.html#compile-for-your-target-board>`_
+
+----------------------------------------------------------------
+
+Flashing
+--------
+
+.. note:: Before proceeding, make sure the device is in DFU mode.
+
+This sample can be flashed to a board as follows:
+
+- Using the KNoT Zephyr SDK on your machine:
+
+   Follow the steps described on `KNoT CLI section. <../../thing-cli.html#flash-board-when-done>`_
+
+- Using the KNoT Docker:
+
+   Follow the steps described on `KNoT Docker section. <../../thing-docker.html#flashing>`_
+
+----------------------------------------------------------------
+
+Configuring
+-----------
+
+After flashing, use the Android KNoT Setup App for configuring the Gateway credentials on your thing.

--- a/doc/thing/samples/sensor-samples/analog-alert.rst
+++ b/doc/thing/samples/sensor-samples/analog-alert.rst
@@ -1,0 +1,53 @@
+analog-alert
+============
+
+Overview
+--------
+
+The analog-alert example reads an analog sensor, convert the read value to float and depending on a threshold value it lights an LED.
+
+----------------------------------------------------------------
+
+Requirements
+------------
+
+The demo assumes that an analog output is connected to the 0.31 pin. Make sure to use VDD OUT as the positive reference and GND as the negative reference.
+
+----------------------------------------------------------------
+
+Building
+--------
+
+This sample can be built for your board in two different ways.
+
+- Using the KNoT Zephyr SDK installed on your machine:
+
+   Follow the steps described on `KNoT CLI section. <../../thing-cli.html#compile-for-your-target-board>`_
+
+- Using the KNoT Docker:
+
+   Follow the steps described on `KNoT Docker section. <../../thing-docker.html#compile-for-your-target-board>`_
+
+----------------------------------------------------------------
+
+Flashing
+--------
+
+.. note:: If you are flashing the ``dongle`` (nrf52840_pca10059) board, make sure the device is in DFU mode before proceeding.
+
+This sample can be flashed to a board as follows:
+
+- Using the KNoT Zephyr SDK on your machine:
+
+   Follow the steps described on `KNoT CLI section. <../../thing-cli.html#flash-board-when-done>`_
+
+- Using the KNoT Docker:
+
+   Follow the steps described on `KNoT Docker section. <../../thing-docker.html#flashing>`_
+
+----------------------------------------------------------------
+
+Configuring
+-----------
+
+After flashing, use the Android KNoT Setup App for configuring the Gateway credentials on your thing.

--- a/doc/thing/samples/sensor-samples/digital-counter.rst
+++ b/doc/thing/samples/sensor-samples/digital-counter.rst
@@ -1,0 +1,54 @@
+digital-counter
+===============
+
+Overview
+--------
+
+The digital-counter example reads a digital sensor and counts how many times the sensor was triggered.
+It lights an LED for 1 second when the sensor is triggered.
+
+----------------------------------------------------------------
+
+Requirements
+------------
+
+The demo assumes that a digital output is connected to pin 0.10.
+
+----------------------------------------------------------------
+
+Building
+--------
+
+This sample can be built for your board in two different ways.
+
+- Using the KNoT Zephyr SDK installed on your machine:
+
+   Follow the steps described on `KNoT CLI section. <../../thing-cli.html#compile-for-your-target-board>`_
+
+- Using the KNoT Docker:
+
+   Follow the steps described on `KNoT Docker section. <../../thing-docker.html#compile-for-your-target-board>`_
+
+----------------------------------------------------------------
+
+Flashing
+--------
+
+.. note:: If you are flashing the ``dongle`` (nrf52840_pca10059) board, make sure the device is in DFU mode before proceeding.
+
+This sample can be flashed to a board as follows:
+
+- Using the KNoT Zephyr SDK on your machine:
+
+   Follow the steps described on `KNoT CLI section. <../../thing-cli.html#flash-board-when-done>`_
+
+- Using the KNoT Docker:
+
+   Follow the steps described on `KNoT Docker section. <../../thing-docker.html#flashing>`_
+
+----------------------------------------------------------------
+
+Configuring
+-----------
+
+After flashing, use the Android KNoT Setup App for configuring the Gateway credentials on your thing.

--- a/doc/thing/samples/thing-basic-samples.rst
+++ b/doc/thing/samples/thing-basic-samples.rst
@@ -1,0 +1,6 @@
+Basic Samples
+=============
+
+.. toctree::
+
+   basic-samples/hello-dongle

--- a/doc/thing/samples/thing-sensor-samples.rst
+++ b/doc/thing/samples/thing-sensor-samples.rst
@@ -3,4 +3,5 @@ Sensor Samples
 
 .. toctree::
 
+   sensor-samples/analog-alert
    sensor-samples/digital-counter

--- a/doc/thing/samples/thing-sensor-samples.rst
+++ b/doc/thing/samples/thing-sensor-samples.rst
@@ -1,0 +1,6 @@
+Sensor Samples
+==============
+
+.. toctree::
+
+   sensor-samples/digital-counter

--- a/doc/thing/thing-samples.rst
+++ b/doc/thing/thing-samples.rst
@@ -5,3 +5,4 @@ Samples
 :maxdepth: 1
 
    samples/thing-basic-samples
+   samples/thing-sensor-samples

--- a/doc/thing/thing-samples.rst
+++ b/doc/thing/thing-samples.rst
@@ -2,3 +2,6 @@ Samples
 =======
 
 .. toctree::
+:maxdepth: 1
+
+   samples/thing-basic-samples


### PR DESCRIPTION
Add thing samples information. The documentation for the following samples were added:
- hello-dongle
- digital-counter
- analog-alert