### PR TITLE
thing: cli: Reorganize the compile section 

### DIFF
--- a/doc/thing/thing-cli.rst
+++ b/doc/thing/thing-cli.rst
@@ -61,9 +61,9 @@ Compile for your target board
 
 .. code-block:: bash
 
-   container> $ knot make -b {BOARD}
+   $ knot make -b {BOARD}
 
-.. note:: Currently, KNoT support ``dk`` (nrf52840_pca10056) or ``dongle`` (nrf52840_pca10059) board. Replace {BOARD} with one of them.
+.. note:: Currently, KNoT supports ``dk`` (nrf52840_pca10056) or ``dongle`` (nrf52840_pca10059) board. Replace {BOARD} by one of them.
 
 .. note:: If you already set the default board is not necessary compile with -b option.
 

--- a/doc/thing/thing-cli.rst
+++ b/doc/thing/thing-cli.rst
@@ -59,11 +59,13 @@ The user can delete old building files before compiling again.
 Compile for your target board
 -----------------------------
 
+.. warning:: The build command must be run from an application folder.
+
+Currently, KNoT supports ``dk`` (nrf52840_pca10056) or ``dongle`` (nrf52840_pca10059) board. Replace {BOARD} by one of them.
+
 .. code-block:: bash
 
    $ knot make -b {BOARD}
-
-.. note:: Currently, KNoT supports ``dk`` (nrf52840_pca10056) or ``dongle`` (nrf52840_pca10059) board. Replace {BOARD} by one of them.
 
 .. note:: If you already set the default board is not necessary compile with -b option.
 


### PR DESCRIPTION
Reorganize the compile section by:
- Adding a note to run the build command from application folder
- Moving note specifying supported boards 
- Fix typo