### PR TITLE
thing: requirements: Simplify readability

### DIFF
--- a/doc/thing/thing-requirements.rst
+++ b/doc/thing/thing-requirements.rst
@@ -5,132 +5,182 @@ Linux based OS
 --------------
 
 The actual version of KNoT Zephyr SDK is only available for Linux based systems.
-On other systems, you may consider using the `KNoT Docker <thing-docker.html>`_ (recommended) or a Virtual Machine running a Linux distribution.
+
+For other systems, you may consider using the `KNoT Docker <thing-docker.html>`_ (recommended) or a Virtual Machine running a Linux distribution.
 
 ----------------------------------------------------------------
 
 Zephyr
 ------
 
-KNoT uses a fork of Zephyr repository.
+Set up a Zephyr development environment.
 
-- Set up a Zephyr development environment by following these `instructions <https://docs.zephyrproject.org/latest/getting_started/installation_linux.html>`_.
+.. note:: This section is based on `Zephyr instructions <https://docs.zephyrproject.org/1.14.0/getting_started/installation_linux.html>`_ and considers a Linux version based on Debian as host.
 
-- Program the ``$HOME/.profile`` to always set **ZEPHYR_TOOLCHAIN_VARIANT** and **ZEPHYR_SDK_INSTALL_DIR**.
+Update Your Operating System
+''''''''''''''''''''''''''''
 
-.. code-block:: bash
+- Ensure your host system is up to date.
 
-   $ echo "export ZEPHYR_TOOLCHAIN_VARIANT=zephyr" >> $HOME/.profile
-   $ echo "export ZEPHYR_SDK_INSTALL_DIR=`readlink -f <SDK-INSTALLATION-DIRECTORY>`" >> $HOME/.profile
+   .. code-block:: bash
 
-.. note:: Replace ``<SDK-INSTALLATION-DIRECTORY>`` by the actual Zephyr SDK install path
+      sudo apt update
+      sudo apt upgrade
 
-- Install the west binary and bootstrapper
+Install Requirements and Dependencies
+'''''''''''''''''''''''''''''''''''''
 
-.. code-block:: bash
+#. Install Zephyr's dependencies.
 
-   $ pip3 install --user west
+   .. code-block:: bash
 
-- Create an enclosing folder and change directory
+      sudo apt install --no-install-recommends git ninja-build gperf \
+           ccache dfu-util device-tree-compiler wget \
+           python3-pip python3-setuptools python3-tk python3-wheel xz-utils file \
+           make gcc gcc-multilib
 
-.. code-block:: bash
+#. Install OpenThread and KNoT Protocol dependencies. These are external packages used by Zephyr and KNoT SDK.
 
-   $ mkdir zephyrproject
-   $ cd zephyrproject
+   .. code-block:: bash
 
-- Clone KNoT Zephyr fork
+      sudo apt install autoconf automake libtool
 
-.. code-block:: bash
+#. Install CMake v3.13.1.
 
-   $ git clone -b zephyr-knot-v1.14.0 https://github.com/CESARBR/zephyr.git
+   .. code-block:: bash
 
-- Initialize west. Inside zephyrproject directory run:
+      mkdir -p $HOME/bin/cmake && cd $HOME/bin/cmake && \
+           wget https://github.com/Kitware/CMake/releases/download/v3.13.1/cmake-3.13.1-Linux-x86_64.sh && \
+           yes | sh cmake-3.13.1-Linux-x86_64.sh | cat && \
+           echo "export PATH=$HOME/bin/cmake/cmake-3.13.1-Linux-x86_64/bin:\$PATH" >> $HOME/.zephyrrc
 
-.. code-block:: bash
+   .. note:: CMake version 3.13.1 or higher is required.
 
-   $ west init -l zephyr/
-   $ west update
+Install the Zephyr SDK
+''''''''''''''''''''''
 
-.. note:: If the system can't find west, try logging out and in again.
+#. Download and run the Zephyr SDK setup file.
 
-- Set up zephyr environment variables
+   .. code-block:: bash
 
-.. code-block:: bash
+      wget -O $HOME/Downloads/zephyr-sdk-0.10.0-setup.run https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.10.0/zephyr-sdk-0.10.0-setup.run && \
+           chmod +x $HOME/Downloads/zephyr-sdk-0.10.0-setup.run  && \
+           $HOME/Downloads/zephyr-sdk-0.10.0-setup.run -- -d ~/zephyr-sdk-0.10.0
 
-   $ source zephyr/zephyr-env.sh
+#. Program the ``$HOME/.profile`` to always set **ZEPHYR_TOOLCHAIN_VARIANT** and **ZEPHYR_SDK_INSTALL_DIR**.
 
-- Program the ``$HOME/.profile`` to always source zephyr-env.sh when you log in.
+   .. code-block:: bash
 
-.. code-block:: bash
+      echo "export ZEPHYR_TOOLCHAIN_VARIANT=zephyr" >> $HOME/.profile
+      echo "export ZEPHYR_SDK_INSTALL_DIR=$HOME/zephyr-sdk-0.10.0" >> $HOME/.profile
 
-   $ echo "source $ZEPHYR_BASE/zephyr-env.sh" >> $HOME/.profile
+Set up the Zephyr Environment
+'''''''''''''''''''''''''''''
 
-.. note:: If you skip this step, it will be necessary to manually source zephyr-env.sh every time a new terminal is opened.
+#. If you do not have ``~/.local/bin`` on your PATH environment variable, add it.
+
+   .. code-block:: bash
+
+      echo PATH=\"$HOME/.local/bin:'$PATH'\" >> $HOME/.profile
+      source $HOME/.profile
+
+#. Install the west binary and bootstrapper.
+
+   .. code-block:: bash
+
+      pip3 install --user west
+
+#. Clone KNoT Zephyr fork.
+
+   .. code-block:: bash
+
+      git clone -b zephyr-knot-v1.14.0 https://github.com/CESARBR/zephyr.git $HOME/zephyrproject/zephyr/
+
+   .. note:: It will create a folder under $HOME directory and clone zephyr inside it. Make sure to update the path on the following steps if you clone it under another folder.
+
+#. Initialize west.
+
+   .. code-block:: bash
+
+      cd $HOME/zephyrproject/
+      west init -l zephyr/
+      west update
+
+   .. note:: If the system can't find west, try logging out and in again.
+
+#. Program the ``$HOME/.profile`` to always source zephyr-env.sh when you log in.
+
+   .. code-block:: bash
+
+      echo "source $HOME/zephyrproject/zephyr/zephyr-env.sh" >> $HOME/.profile
+
+   .. note:: If you skip this step, it will be necessary to manually source zephyr-env.sh every time a new terminal is opened.
 
 ----------------------------------------------------------------
 
 nRF5x Command Line Tools and Segger JLink
 -----------------------------------------
 
-- Download and extract cli applications at `nRF5 Command Line Tools <https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF5-Command-Line-Tools>`_.
+Download and extract cli applications from `nRF5 Command Line Tools <https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF-Command-Line-Tools>`_ or following the step bellow.
 
-- Install nRF5x Command Line and Segger JLink deb package:
+#. Download nRF5 Command Line Tools.
 
-.. code-block:: bash
+   .. code-block:: bash
 
-   $ dpkg -i nrf5_tools/nRF-Command-Line-Tools_10_2_1_Linux-amd64.deb
-   $ dpkg -i nrf5_tools/JLink_Linux_V644e_x86_64.deb
+      wget -O $HOME/Downloads/nRFCommandLineTools1021tar.gz https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/nRFCommandLineTools1021Linuxamd64tar.gz
+
+#. Extract nRF5 Command Line Tools.
+
+   .. code-block:: bash
+
+      tar -xvzf $HOME/Downloads/nRFCommandLineTools1021tar.gz -C $HOME/Downloads --one-top-level
+
+#. Install nRF5x Command Line and Segger JLink deb packages.
+
+   .. code-block:: bash
+
+      sudo dpkg -i $HOME/Downloads/nRFCommandLineTools1021tar/nRF-Command-Line-Tools_10_2_1_Linux-amd64.deb
+      sudo dpkg -i $HOME/Downloads/nRFCommandLineTools1021tar/JLink_Linux_V644e_x86_64.deb
 
 ----------------------------------------------------------------
 
-Source KNoT environment configuration file
-------------------------------------------
+Set up the KNoT SKD Environment
+-------------------------------
 
-- Download the zephyr-knot-sdk repository to a folder you prefer.
+#. Download the zephyr-knot-sdk repository.
 
-.. code-block:: bash
+   .. code-block:: bash
 
-   $ git clone https://github.com/cesarbr/zephyr-knot-sdk/
+      git clone https://github.com/cesarbr/zephyr-knot-sdk/ $HOME/zephyr-knot-sdk/
 
-- The environment configuration file is used to set up **KNOT_BASE** path.
+   .. note:: The default clone path is the $HOME directory. Make sure to update the path on the following steps if you create it under another folder.
 
-.. code-block:: bash
+#. Program the ``$HOME/.profile`` to always source knot-env.sh when you log in. The environment configuration file is used to set up **$KNOT_BASE** path.
 
-   $ source zephyr-knot-sdk/knot-env.sh
+   .. code-block:: bash
 
-- Program the ``$HOME/.profile`` to always source knot-env.sh when you log in.
+      echo "source $HOME/zephyr-knot-sdk/knot-env.sh" >> $HOME/.profile
 
-.. code-block:: bash
-
-   $ echo "source $KNOT_BASE/knot-env.sh" >> $HOME/.profile
+   .. note:: If you skip this step, it will be necessary to manually source knot-env.sh every time a new terminal is opened.
 
 ----------------------------------------------------------------
 
 Add support to the KNoT command line interface
 ----------------------------------------------
 
-- Add cli.py to the path files.
+#. Add cli.py to the path files.
 
-.. code-block:: bash
+   .. code-block:: bash
 
-   $ ln -s $KNOT_BASE/scripts/cli.py $HOME/.local/bin/knot
+      ln -s $HOME/zephyr-knot-sdk/scripts/cli.py $HOME/.local/bin/knot
 
-.. note:: This will allow you to call the knot command line interface from any folder.
+   .. note:: This will allow you to call the ``knot`` command line interface from any folder.
 
-- Use pip to install cli requirements
+#. Use pip to install cli requirements.
 
-.. code-block:: bash
+   .. code-block:: bash
 
-   $ pip3 install --user -r ${KNOT_BASE}/scripts/requirements.txt
-
-.. note:: If you skip this step, it will be necessary to manually source knot-env.sh every time a new terminal is opened.
-
-----------------------------------------------------------------
-
-KNoT protocol
--------------
-
-- Follow the instructions to install the `KNoT protocol library <https://github.com/CESARBR/knot-protocol-source>`_.
+      pip3 install --user -r $HOME/zephyr-knot-sdk/scripts/requirements.txt
 
 ----------------------------------------------------------------
 
@@ -139,13 +189,17 @@ Add USB access to your user
 
 - Add your user to the dialout group.
 
-.. code-block:: bash
+   .. code-block:: bash
 
-   $ sudo usermod -a -G dialout `whoami`
+      sudo usermod -a -G dialout `whoami`
 
 ----------------------------------------------------------------
 
 Apply changes to profile
 ------------------------
 
-- In order to apply the changes to your user, you must log out and log in again.
+- In order to apply the changes to your user, you must log out and log in again or reboot you system.
+
+   .. code-block:: bash
+
+      reboot


### PR DESCRIPTION
Add information and change document structure to simplify thing
requirements readability. It resolves #17 . 

Changes:
	- Add Zephyr development environment setup information.
	- Replace relative paths for absolute paths.
	- Number all steps.
	- Remove KNoT Protocol section.
	- Remove heading "$" from code-blocks.
	- Fix syntax.