### PR TITLE
thing: Fix SDK typo in KNoT Thing requirements

### DIFF
--- a/doc/thing/thing-requirements.rst
+++ b/doc/thing/thing-requirements.rst
@@ -144,7 +144,7 @@ Download and extract cli applications from `nRF5 Command Line Tools <https://www
 
 ----------------------------------------------------------------
 
-Set up the KNoT SKD Environment
+Set up the KNoT SDK Environment
 -------------------------------
 
 #. Download the zephyr-knot-sdk repository.


### PR DESCRIPTION
fixing minor typo in KNoT Thing Requirements where its read `SKD` I think it should be `SDK`.
