### PR TITLE
Add information about using an external DTS overlay

### DIFF
--- a/doc/thing/thing-cli.rst
+++ b/doc/thing/thing-cli.rst
@@ -85,6 +85,9 @@ absolute file path.
 
    $ knot make --dts_ovl_path {PATH}
 
+.. note:: If the application folder has an overlay file this command will
+          ignore it.
+
 ----------------------------------------------------------------
 
 Flash board when done

--- a/doc/thing/thing-cli.rst
+++ b/doc/thing/thing-cli.rst
@@ -73,6 +73,20 @@ Currently, KNoT supports ``dk`` (nrf52840_pca10056) or ``dongle`` (nrf52840_pca1
 
 ----------------------------------------------------------------
 
+Use an external DTS overlay file
+--------------------------------
+
+.. warning:: The build command must be run from an application folder.
+
+It is possible to use an external DTS overlay file on the project by passing the
+absolute file path.
+
+.. code-block:: bash
+
+   $ knot make --dts_ovl_path {PATH}
+
+----------------------------------------------------------------
+
 Flash board when done
 ---------------------
 

--- a/doc/thing/thing-create-app.rst
+++ b/doc/thing/thing-create-app.rst
@@ -9,6 +9,7 @@ A general application for a KNoT Thing has the following structure:
     ├── CMakeLists.txt
     ├── prj.conf
     ├── setup.conf
+    ├── <board>.overlay (optional)
     └── src/
         └── <app-name>.c
 
@@ -80,6 +81,14 @@ setup.conf is a configuration file tha contains information about bluetooth conf
    CONFIG_BT_DEVICE_NAME="BLE device name"
 
 Change the name of bluetooth advertise name (``line 1``).
+
+----------------------------------------------------------------
+
+<board>.overlay (optional)
+--------------------------
+
+It is possible to use a DTS overlay file on the project by adding a file named
+<board>.overlay and placing it on the application main directory.
 
 ----------------------------------------------------------------
 


### PR DESCRIPTION
Add information about using an external DTS overlay by passing its path via CLI or placing the file on the application folder.