### PR TITLE
Changed KNoT CLI commands to prevent lack of permissions in the Docker container

### DIFF
--- a/doc/quick-start/qs-guide.rst
+++ b/doc/quick-start/qs-guide.rst
@@ -130,13 +130,13 @@ Compiling project
 
       .. code-block:: bash
 
-         [user@container] $ knot make --board dk
+         [user@container] $ sudo -E knot make --board dk
 
    - If using the `KNoT Dongle <https://docs.zephyrproject.org/latest/boards/arm/nrf52840_pca10059/doc/index.html>`_:
 
       .. code-block:: bash
 
-         [user@container] $ knot make --board dongle
+         [user@container] $ sudo -E knot make --board dongle
 
 
 Flashing board
@@ -146,7 +146,7 @@ Flashing board
 
    .. code-block:: bash
 
-      [user@container] $ knot export output/
+      [user@container] $ sudo -E knot export output/
 
 #. Install `nRF Connect <https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF-Connect-for-desktop/Download>`_.
 

--- a/doc/thing/thing-docker.rst
+++ b/doc/thing/thing-docker.rst
@@ -44,7 +44,7 @@ Compile for your target board
 
 .. code-block:: bash
 
-   container> $ sudo -E knot make -b {BOARD}
+   [user@container] $ sudo -E knot make -b {BOARD}
 
 .. note:: Currently, KNoT support ``dk`` (nrf52840_pca10056) or ``dongle`` (nrf52840_pca10059) board. Replace {BOARD} with one of them.
 
@@ -64,7 +64,7 @@ Export the generated files to your project's directory
 
 .. code-block:: bash
 
-   container> $ sudo -E knot export /workdir/output
+   [user@container] $ sudo -E knot export /workdir/output
 
 The generated files can now be flashed to your device by using the
 `nRF Connect for Desktop <https://www.nordicsemi.com/?sc_itemid=%7B49D2264D-62FD-4C16-811F-88B477833C5D%7D>`_ and its
@@ -100,7 +100,7 @@ This will allow you to use the `--flash` flag to flash after building the projec
 
 .. code-block:: bash
 
-   container> $ sudo -E knot make -b {BOARD} --mcuboot
+   [user@container] $ sudo -E knot make -b {BOARD} --mcuboot
 
 .. note:: Currently, KNoT support ``dk`` (nrf52840_pca10056) or ``dongle`` (nrf52840_pca10059) board. Replace {BOARD} with one of them.
 
@@ -115,6 +115,6 @@ To get a list of all available commands, run:
 
 .. code-block:: bash
 
-   container> $ knot --help
+   [user@container] $ knot --help
 
 More info is available at the `Thing CLI doc section <thing-cli.html>`_.

--- a/doc/thing/thing-docker.rst
+++ b/doc/thing/thing-docker.rst
@@ -44,7 +44,7 @@ Compile for your target board
 
 .. code-block:: bash
 
-   container> $ knot make -b {BOARD}
+   container> $ sudo -E knot make -b {BOARD}
 
 .. note:: Currently, KNoT support ``dk`` (nrf52840_pca10056) or ``dongle`` (nrf52840_pca10059) board. Replace {BOARD} with one of them.
 
@@ -64,7 +64,7 @@ Export the generated files to your project's directory
 
 .. code-block:: bash
 
-   container> $ knot export /workdir/output
+   container> $ sudo -E knot export /workdir/output
 
 The generated files can now be flashed to your device by using the
 `nRF Connect for Desktop <https://www.nordicsemi.com/?sc_itemid=%7B49D2264D-62FD-4C16-811F-88B477833C5D%7D>`_ and its
@@ -100,7 +100,7 @@ This will allow you to use the `--flash` flag to flash after building the projec
 
 .. code-block:: bash
 
-   container> $ knot make -b {BOARD} --mcuboot
+   container> $ sudo -E knot make -b {BOARD} --mcuboot
 
 .. note:: Currently, KNoT support ``dk`` (nrf52840_pca10056) or ``dongle`` (nrf52840_pca10059) board. Replace {BOARD} with one of them.
 

--- a/doc/thing/thing-docker.rst
+++ b/doc/thing/thing-docker.rst
@@ -42,6 +42,8 @@ by the tag you used.
 Compile for your target board
 -----------------------------
 
+Inside the docker container, use the KNoT script to compile your project.
+
 .. code-block:: bash
 
    [user@container] $ sudo -E knot make -b {BOARD}


### PR DESCRIPTION
When host OS's user ID isn't the same as the container's user ID, the user inside the container can't write to the working directory, which in turn fail the KNoT CLI's `make`, `export` and `build` commands, described in both the Quickstart and KNoT Thing sections of the documentation.

This can be fixed by prepending the commands with the `sudo -E`, so they run as SU and the env vars are preserved, which are required for the KNoT CLI script.

https://github.com/kbcvcbk/knot-documentation